### PR TITLE
Fix Cargo Install errors

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -27,7 +27,7 @@ fn read_version(obj: &object::File<'_>) -> anyhow::Result<String> {
         },
       };
       for section in obj.sections() {
-        if section.address() <= addr.into() && (section.address() + section.data()?.len() as u64) > (addr + str_len) as u64 {
+        if section.address() <= addr as u64 && (section.address() + section.data()?.len() as u64) > (addr + str_len) as u64 {
           let offset = addr as usize - section.address() as usize;
           let version_str = &section.data()?[offset..offset+str_len as usize];
           

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -84,7 +84,7 @@ pub fn flash<T: Read>(session: &mut Session, read: &mut T) -> anyhow::Result<()>
     ProgressEvent::SectorErased { size, .. } => {
         erase_progress.inc(size);
     }
-    ProgressEvent::PageFilled { size, .. } => { }
+    ProgressEvent::PageFilled {  .. } => { }
     ProgressEvent::FailedErasing => {
         erase_progress.abandon();
         program_progress.abandon();

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::File, io::Read};
+use std::{fs::File, io::Read};
 
 use rust_embed::RustEmbed;
 use serde::Deserialize;


### PR DESCRIPTION
For Issue #1 

This allows `cargo install` to be completed on Ubuntu and I have tested `grapple-bundle flash` but haven't tested any other commands.

I have also used the low-cost [STLINK-V3MODS](https://www.st.com/en/development-tools/stlink-v3mods.html) to flash the laserCAN with success. Tip for anyone else using V3mods and the CN5 connector, you need to solder the top 5 jumper pads.